### PR TITLE
Shipment cost's comment extension

### DIFF
--- a/server/routes/shipment_cost.js
+++ b/server/routes/shipment_cost.js
@@ -14,22 +14,15 @@ const {
   },
   userScore,  // (float)
   paymentMethod, // (string)
-  price, // (float)
-  shippingCharacteristics: {
-    duration,  // (float)
-    distance,  // (float)
-    geographicalPosition: {
-      latitud,  // (float)
-      longitud // (float)
-    },
-    date, // (string: YYYY/MM/DD)
-    time // (string: HH:MM)
+  geographicalPosition: {
+    latitud,  // (float)
+    longitud // (float)
   },
-  serverId, // (int)
   tripDate, // (string: YYYY/MM/DD)
   tripTime // (string: HH:MM)
 } = req.body
-  */
+see also: https://github.com/Taller-2/shared-server/wiki/Development#explicacion-de-que-tipo-de-datos-recibe-el-endpoint-shipment-cost
+*/
 
 router.post('/', bodyParser.json(), shipmentCostController.getCost)
 

--- a/server/routes/shipment_cost.js
+++ b/server/routes/shipment_cost.js
@@ -14,9 +14,12 @@ const {
   },
   userScore,  // (float)
   paymentMethod, // (string)
-  geographicalPosition: {
-    latitud,  // (float)
-    longitud // (float)
+  shippingCharacteristics: {
+    distance,  // (float)
+    geographicalPosition: {
+      latitude,  // (float)
+      longitude // (float)
+    }
   },
   tripDate, // (string: YYYY/MM/DD)
   tripTime // (string: HH:MM)

--- a/server/routes/shipment_cost.js
+++ b/server/routes/shipment_cost.js
@@ -13,9 +13,9 @@ const {
     email, // (string)
   },
   userScore,  // (float)
-  paymentMethod, // (string)
+  paymentMethod, // (string) [debit, credit, cash]
   shippingCharacteristics: {
-    distance,  // (float)
+    distance,  // (float) (KM)
     geographicalPosition: {
       latitude,  // (float)
       longitude // (float)

--- a/test/app_server_test.js
+++ b/test/app_server_test.js
@@ -64,5 +64,6 @@ describe('App server controller', function () {
             done()
           })
       })
+      .catch((err) => (err))
   })
 })


### PR DESCRIPTION
Este branch actualizo que información puede brindar el app server al endpoint shipment-cost y en la wiki se explica que significa cada dato con el tipo de formato de cada uno. Los datos que fueron sacados es porque no eran datos que el app server pueda conocer, son datos que o conoce el shared server como el id del app server o datos que se calculen a partir de otros