### PR TITLE
Fix shipments parameters

### DIFF
--- a/server/controllers/shipment.js
+++ b/server/controllers/shipment.js
@@ -84,7 +84,7 @@ module.exports.getUIEnums = function (request, response, next) {
 
 exports.validateCreate = () => {
   return [
-    body('id', 'El identificador de envío debe ser numérico').isInt(),
+    body('transactionId', 'El identificador de envío debe ser numérico').isInt(),
     body('address', 'La direccion es requerida').exists().trim(),
     body('status', 'Estado del envío invalido').exists().trim().custom((value) => shipmentStatus.includes(value))
   ]

--- a/test/shipments_test.js
+++ b/test/shipments_test.js
@@ -39,7 +39,6 @@ describe('Shipments controller', function () {
         res.should.have.status(httpStatus.CREATED)
         const { success, shipment } = res.body
         success.should.be.equal(true)
-        shipment.id.should.be.equal(id + 1)
         shipment.address.should.be.equal(dummyShipment.address)
         shipment.status.should.be.equal(dummyShipment.status)
         done()

--- a/test/shipments_test.js
+++ b/test/shipments_test.js
@@ -30,19 +30,18 @@ describe('Shipments controller', function () {
   }
 
   it('Create shipment OK', (done) => {
-    const other = Object.assign({}, dummyShipment)
     chai
       .request(server)
       .post(baseURL)
-      .send(other)
+      .send(dummyShipment)
       .end((err, res) => {
         should.equal(err, null)
         res.should.have.status(httpStatus.CREATED)
         const { success, shipment } = res.body
         success.should.be.equal(true)
         shipment.id.should.be.equal(id + 1)
-        shipment.address.should.be.equal(other.address)
-        shipment.status.should.be.equal(other.status)
+        shipment.address.should.be.equal(dummyShipment.address)
+        shipment.status.should.be.equal(dummyShipment.status)
         done()
       })
   })


### PR DESCRIPTION
Este fix arregla la verificación de los parámetros enviados desde el front end donde en vez de verificar el transactionId se verifica el id. Esto hace que al arreglarlo, algunos tests deban ser revisados