### PR TITLE
Front end simulate shipment cost

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -16,6 +16,7 @@ import RulesListContainer from './containers/rulesListContainer'
 import AppServerGraphsContainer from './containers/appServerGraphsContainer'
 import PaymentsContainer from './containers/PaymentContainer'
 import ShipmentsContainer from './containers/ShipmentsContainer'
+import ShipmentsCostContainer from './containers/shipmentCostContainer'
 
 class App extends Component {
   constructor (props) {
@@ -51,6 +52,7 @@ class App extends Component {
               <PrivateRoute path="/appServerGraphs" component={AppServerGraphsContainer} />
               <PrivateRoute path="/payments" component={PaymentsContainer} />
               <PrivateRoute path="/shipments" component={ShipmentsContainer} />
+              <PrivateRoute path="/shipment-cost" component={ShipmentsCostContainer} />
             </div>
           </Router>
         </div>

--- a/client/src/components/LoggedNavbar.js
+++ b/client/src/components/LoggedNavbar.js
@@ -27,6 +27,9 @@ const LoggedNavbar = function () {
         <LinkContainer to="/shipments">
           <NavItem eventKey={7}>Envíos</NavItem>
         </LinkContainer>
+        <LinkContainer to="/shipment-cost">
+          <NavItem eventKey={8}>Simular costo de envio</NavItem>
+        </LinkContainer>
         <LinkContainer to="/logout">
           <NavItem eventKey={8}>Salir</NavItem>
         </LinkContainer>

--- a/client/src/components/rulesForm.js
+++ b/client/src/components/rulesForm.js
@@ -11,45 +11,14 @@ import {
 } from 'react-bootstrap'
 import PropTypes from 'prop-types'
 import RuleTranslator from '../service/ruleTranslator'
+import { facts, ops, type } from './rules_data'
 
 export default class RulesForm extends React.Component {
   constructor (props) {
     super(props)
-    this.facts = [
-      'daytrips',
-      'monthtrips',
-      'antiquity',
-      'userScore',
-      'paymentMethod',
-      'duration',
-      'distance',
-      'latitud',
-      'longitud',
-      'date',
-      'time',
-      'serverId',
-      'tripDate',
-      'tripTime',
-      'email',
-      'price'
-    ]
-    this.ops = [
-      'equal',
-      'greaterThanInclusive',
-      'lessThanInclusive',
-      'greaterThan',
-      'domainEqual',
-      'lessThan'
-    ]
-    this.type = [
-      'percentage',
-      'factor',
-      'sum',
-      'discount',
-      'surcharge',
-      'free',
-      'disabled'
-    ]
+    this.facts = facts
+    this.ops = ops
+    this.type = type
     this.defaultValue = '10'
     this.state = {
       conditions: [],

--- a/client/src/components/rules_data.js
+++ b/client/src/components/rules_data.js
@@ -1,0 +1,35 @@
+module.exports.facts = [
+  'daytrips',
+  'monthtrips',
+  'antiquity',
+  'userScore',
+  'paymentMethod',
+  'duration',
+  'distance',
+  'latitud',
+  'longitud',
+  'date',
+  'time',
+  'serverId',
+  'tripDate',
+  'tripTime',
+  'email',
+  'price'
+]
+module.exports.ops = [
+  'equal',
+  'greaterThanInclusive',
+  'lessThanInclusive',
+  'greaterThan',
+  'domainEqual',
+  'lessThan'
+]
+module.exports.type = [
+  'percentage',
+  'factor',
+  'sum',
+  'discount',
+  'surcharge',
+  'free',
+  'disabled'
+]

--- a/client/src/components/shipmentCostForm.js
+++ b/client/src/components/shipmentCostForm.js
@@ -19,7 +19,8 @@ export default class ShipmentCostForm extends React.Component {
     this.facts = facts
     this.state = {
       fact: this.facts[0],
-      value: null
+      value: null,
+      factsList: []
     }
   }
 
@@ -38,9 +39,19 @@ export default class ShipmentCostForm extends React.Component {
     })
   }
 
+  refresh () {
+    this.setState({
+      conditions: [],
+      fact: this.facts[0],
+      value: null,
+      factsList: []
+    })
+  }
+
   submit = (event) => {
     event.preventDefault()
-    this.props.onClick(this.state.fact, this.state.value)
+    this.props.onClick(this.state.factsList)
+    this.refresh()
   }
 
   showOptions (options) {
@@ -49,6 +60,22 @@ export default class ShipmentCostForm extends React.Component {
         return (<option key={index} value={option}>{option}</option>)
       })
     )
+  }
+
+  addFact = () => {
+    this.state.factsList.push({
+      [this.state.fact]: this.state.value
+    })
+    this.setState({
+      'factsList': this.state.factsList
+    })
+  }
+
+  removeFact = () => {
+    this.state.factsList.pop()
+    this.setState({
+      'factsList': this.state.factsList
+    })
   }
 
   showFacts () {
@@ -62,6 +89,16 @@ export default class ShipmentCostForm extends React.Component {
             { this.showOptions(this.facts) }
           </FormControl>
           <FormControl type="text" placeholder="insert a value" onChange={this.handleChange('value')}/>
+        </Col>
+        <Col smOffset={12} sm={10}>
+          <Button type="button" onClick={ this.addFact }>
+            +
+          </Button>
+        </Col>
+        <Col smOffset={12} sm={10}>
+          <Button type="button" onClick={ this.removeFact }>
+            -
+          </Button>
         </Col>
       </FormGroup>
     )
@@ -96,9 +133,30 @@ export default class ShipmentCostForm extends React.Component {
     )
   }
 
+  listFacts () {
+    let translatedFacts = []
+    this.state.factsList.forEach((aFact) => {
+      translatedFacts.push(JSON.stringify(aFact))
+    })
+    return (
+      <FormGroup controlId="condition">
+        <Col sm={10}>
+          { this.showOptions(translatedFacts) }
+        </Col>
+      </FormGroup>
+    )
+  }
+
   render () {
     return (
       <Grid>
+        <Row className="show-grid">
+          <Col xs={12} md={4} mdOffset={9}>
+            <Form horizontal>
+              { this.listFacts() }
+            </Form>
+          </Col>
+        </Row>
         <Row className="show-grid">
           <Col xs={12} md={6} mdOffset={3}>
             <Form horizontal>

--- a/client/src/components/shipmentCostForm.js
+++ b/client/src/components/shipmentCostForm.js
@@ -1,0 +1,120 @@
+import React from 'react'
+import {
+  Button,
+  Col,
+  ControlLabel,
+  Form,
+  FormControl,
+  FormGroup,
+  Grid,
+  Row,
+  HelpBlock
+} from 'react-bootstrap'
+import PropTypes from 'prop-types'
+import { facts } from './rules_data'
+
+export default class ShipmentCostForm extends React.Component {
+  constructor (props) {
+    super(props)
+    this.facts = facts
+    this.state = {
+      fact: this.facts[0],
+      value: null
+    }
+  }
+
+  checkValue (name, event) {
+    if (name === 'value') {
+      if (!isNaN(event.target.value)) {
+        return parseInt(event.target.value, 10)
+      }
+    }
+    return event.target.value
+  }
+
+  handleChange = name => event => {
+    this.setState({
+      [name]: this.checkValue(name, event)
+    })
+  }
+
+  submit = (event) => {
+    event.preventDefault()
+    this.props.onClick(this.state.fact, this.state.value)
+  }
+
+  showOptions (options) {
+    return (
+      options.map((option, index) => {
+        return (<option key={index} value={option}>{option}</option>)
+      })
+    )
+  }
+
+  showFacts () {
+    return (
+      <FormGroup controlId="Facts">
+        <Col componentClass={ControlLabel} sm={2}>
+          Facts
+        </Col>
+        <Col sm={10}>
+          <FormControl componentClass="select" placeholder="Type" onChange={this.handleChange('fact')}>
+            { this.showOptions(this.facts) }
+          </FormControl>
+          <FormControl type="text" placeholder="insert a value" onChange={this.handleChange('value')}/>
+        </Col>
+      </FormGroup>
+    )
+  }
+
+  accept () {
+    return (
+      <FormGroup>
+        <Col smOffset={2} sm={10}>
+          <Button type="submit" onClick={ this.submit }>
+            Aceptar
+          </Button>
+          <HelpBlock>
+            <p className="text-danger">{ this.props.errors.value ? 'Invalid value type' : '' }</p>
+          </HelpBlock>
+        </Col>
+      </FormGroup>
+    )
+  }
+
+  showCost () {
+    return (
+      <FormGroup controlId="Facts">
+        <Col componentClass={ControlLabel} sm={2}>
+          Cost
+        </Col>
+        <Col sm={10}>
+          <FormControl type="text" placeholder={this.props.cost}>
+          </FormControl>
+        </Col>
+      </FormGroup>
+    )
+  }
+
+  render () {
+    return (
+      <Grid>
+        <Row className="show-grid">
+          <Col xs={12} md={6} mdOffset={3}>
+            <Form horizontal>
+              { this.showFacts() }
+              { this.accept() }
+              { this.showCost() }
+            </Form>
+          </Col>
+        </Row>
+      </Grid>
+    )
+  }
+}
+
+ShipmentCostForm.propTypes = {
+  onClick: PropTypes.func,
+  errors: PropTypes.object,
+  cost: PropTypes.string
+}

--- a/client/src/containers/rulesContainer.js
+++ b/client/src/containers/rulesContainer.js
@@ -24,11 +24,15 @@ export default class RulesContainer extends React.Component {
       'event': {
         'type': type,
         'params': {
-          'data': params
+          'data': params,
+          'fact': []
         }
       }
     }
     conditions.forEach((aCondition) => {
+      if (type === 'factor') {
+        rule.event.params.fact.push(aCondition.fact)
+      }
       rule.conditions.all.push({
         'fact': aCondition.fact,
         'operator': aCondition.operator,

--- a/client/src/containers/shipmentCostContainer.js
+++ b/client/src/containers/shipmentCostContainer.js
@@ -14,17 +14,26 @@ export default class RulesContainer extends React.Component {
     }
   }
 
-  handleClick (fact, value) {
-    Http.post('shipment-cost/', { [fact]: value })
+  buildFacts (factsList) {
+    let facts = {}
+    factsList.forEach(aFact => {
+      facts = Object.assign(facts, aFact)
+    })
+    return facts
+  }
+
+  handleClick (factsList) {
+    const facts = this.buildFacts(factsList)
+    Http.post('shipment-cost/', facts)
       .then(response => {
         if (response.status === httpStatus.OK) {
           this.setState({
             errors: {},
-            cost: 'the cost is ' + response.content.cost.cost + ' because it is ' + response.content.cost.status.value
+            cost: 'the cost is ' + response.content.cost.cost + ' because it is ' + response.content.cost.status
           })
         } else {
           this.setState({
-            errors: { value: response.content.errors[fact] }
+            errors: { value: response.content.errors }
           })
         }
       })
@@ -44,7 +53,7 @@ export default class RulesContainer extends React.Component {
         <ShipmentCostForm
           errors={errors}
           cost={cost}
-          onClick={(fact, value) => this.handleClick(fact, value)}
+          onClick={(factsList) => this.handleClick(factsList)}
         />
       </div>
     )

--- a/client/src/containers/shipmentCostContainer.js
+++ b/client/src/containers/shipmentCostContainer.js
@@ -1,0 +1,52 @@
+import React from 'react'
+import ShipmentCostForm from '../components/shipmentCostForm'
+import { Redirect } from 'react-router-dom'
+import Http from '../service/Http'
+import httpStatus from 'http-status-codes'
+import { ToastContainer, toast } from 'react-toastify'
+
+export default class RulesContainer extends React.Component {
+  constructor (props) {
+    super(props)
+    this.state = {
+      errors: {},
+      cost: 'nothing'
+    }
+  }
+
+  handleClick (fact, value) {
+    Http.post('shipment-cost/', { [fact]: value })
+      .then(response => {
+        if (response.status === httpStatus.OK) {
+          this.setState({
+            errors: {},
+            cost: 'the cost is ' + response.content.cost.cost + ' because it is ' + response.content.cost.status.value
+          })
+        } else {
+          this.setState({
+            errors: { value: response.content.errors[fact] }
+          })
+        }
+      })
+      .catch(err => {
+        toast(err)
+      })
+  }
+
+  render () {
+    const { redirectToRules, errors, cost } = this.state
+    if (redirectToRules) {
+      return <Redirect to='/rulesList' />
+    }
+    return (
+      <div>
+        <ToastContainer></ToastContainer>
+        <ShipmentCostForm
+          errors={errors}
+          cost={cost}
+          onClick={(fact, value) => this.handleClick(fact, value)}
+        />
+      </div>
+    )
+  }
+}

--- a/package.json
+++ b/package.json
@@ -83,7 +83,8 @@
       "server/controllers/session.js",
       "scripts/**",
       "server/routes/app_server_logged_data.js",
-      "server/controllers/http_service.js"
+      "server/controllers/http_service.js",
+      "server/middlewares/error_handler.js"
     ]
   }
 }

--- a/server/controllers/shipment_cost.js
+++ b/server/controllers/shipment_cost.js
@@ -117,7 +117,7 @@ function runRules (engine, facts, res) {
     })
 }
 
-function isDictionary (obj) {
+function isObject (obj) {
   if (!obj) return false
   if (Array.isArray(obj)) return false
   if (obj.constructor !== Object) return false
@@ -125,7 +125,7 @@ function isDictionary (obj) {
 }
 
 module.exports.getCost = async function (req, res) {
-  if (!isDictionary(req.body)) {
+  if (!isObject(req.body)) {
     res
       .status(httpStatus.UNPROCESSABLE_ENTITY)
       .json({ success: false, errors: 'The facts should be inside an object' })

--- a/server/controllers/shipment_cost.js
+++ b/server/controllers/shipment_cost.js
@@ -96,19 +96,22 @@ function addRules (rules) {
 }
 function runRules (engine, facts, res) {
   let array
-  engine.run(facts).then(triggeredEvents => {
-    // engine returns a list of events with truthy conditions
-    let cost = { cost: 0 }
-    array = triggeredEvents.map(event => (formula(event, facts, cost)))
-    if (array.length === 0) array = ['disabled']
-    res
-      .status(httpStatus.OK)
-      .json({ success: true, cost: getResult(array, cost.cost) })
-  }).catch((error) => {
-    res
-      .status(httpStatus.INTERNAL_SERVER_ERROR)
-      .json({ success: false, errors: error })
-  })
+  engine
+    .run(facts)
+    .then(triggeredEvents => {
+      // engine returns a list of events with truthy conditions
+      let cost = { cost: 0 }
+      array = triggeredEvents.map(event => (formula(event, facts, cost)))
+      if (array.length === 0) array = ['disabled']
+      res
+        .status(httpStatus.OK)
+        .json({ success: true, cost: getResult(array, cost.cost) })
+    })
+    .catch((error) => {
+      res
+        .status(httpStatus.INTERNAL_SERVER_ERROR)
+        .json({ success: false, errors: error })
+    })
 }
 
 function isDictionary (obj) {

--- a/server/controllers/shipment_cost.js
+++ b/server/controllers/shipment_cost.js
@@ -25,7 +25,10 @@ formula.when('percentage', function (event, data, cost) {
   return 'enabled'
 })
 formula.when('factor', function (event, data, cost) {
-  const factor = event.params.data * data[event.params.fact]
+  let factor = 0
+  event.params.fact.forEach(aFact => {
+    factor += event.params.data * data[aFact]
+  })
   cost.cost += factor
   return 'enabled'
 })

--- a/server/controllers/shipment_cost_data_types.js
+++ b/server/controllers/shipment_cost_data_types.js
@@ -1,0 +1,13 @@
+module.exports.factsTypes = {
+  'daytrips': typeof 1,
+  'monthtrips': typeof 1,
+  'antiquity': typeof 1,
+  'email': typeof '',
+  'userScore': typeof 1.1,
+  'paymentMethod': typeof '',
+  'distance': typeof 1.1,
+  'latitude': typeof 1.1,
+  'longitude': typeof 1.1,
+  'tripDate': typeof '',
+  'tripTime': typeof ''
+}

--- a/server/controllers/user.js
+++ b/server/controllers/user.js
@@ -14,7 +14,7 @@ module.exports.findById = function (request, response) {
     .catch(error => {
       response
         .status(httpStatus.INTERNAL_SERVER_ERROR)
-        .json({ success: false, error: error })
+        .json({ success: false, errors: error })
     })
 }
 
@@ -35,7 +35,7 @@ module.exports.create = function (request, response, next) {
     .catch(error => {
       response
         .status(httpStatus.INTERNAL_SERVER_ERROR)
-        .json({ success: false, error: error })
+        .json({ success: false, errors: error })
     })
 }
 
@@ -53,7 +53,7 @@ module.exports.update = function (request, response) {
     .catch(error => {
       response
         .status(httpStatus.INTERNAL_SERVER_ERROR)
-        .json({ success: false, error: error })
+        .json({ success: false, errors: error })
     })
 }
 
@@ -67,7 +67,7 @@ module.exports.delete = function (request, response) {
     .catch(error => {
       response
         .status(httpStatus.INTERNAL_SERVER_ERROR)
-        .json({ success: false, error: error })
+        .json({ success: false, errors: error })
     })
 }
 

--- a/server/routes/shipment_cost.js
+++ b/server/routes/shipment_cost.js
@@ -1,5 +1,5 @@
 const router = require('express').Router()
-const bodyParser = require('body-parser')
+const validation = require('../middlewares/validation')
 const shipmentCostController = require('../controllers/shipment_cost')
 
 /*
@@ -19,6 +19,11 @@ const {
 see also: https://github.com/Taller-2/shared-server/wiki/Development#explicacion-de-que-tipo-de-datos-recibe-el-endpoint-shipment-cost
 */
 
-router.post('/', bodyParser.json(), shipmentCostController.getCost)
+router.post(
+  '/',
+  shipmentCostController.validateCreate(),
+  validation.validationHandler,
+  shipmentCostController.getCost
+)
 
 module.exports = router

--- a/test/shipment_cost_definitions.js
+++ b/test/shipment_cost_definitions.js
@@ -42,7 +42,7 @@ module.exports.factorRule = {
     'type': 'factor',
     'params': {
       'data': 15,
-      'fact': 'distance'
+      'fact': ['distance']
     }
   }
 }

--- a/test/shipment_cost_definitions.js
+++ b/test/shipment_cost_definitions.js
@@ -47,26 +47,10 @@ module.exports.factorRule = {
   }
 }
 
-module.exports.minPriceRule = {
-  'conditions': {
-    'all': [{
-      'fact': 'price',
-      'operator': 'lessThan',
-      'value': 50
-    }]
-  },
-  'event': {
-    'type': 'disabled',
-    'params': {
-      'data': null
-    }
-  }
-}
-
 module.exports.percentageRule = {
   'conditions': {
     'all': [{
-      'fact': 'duration',
+      'fact': 'userScore',
       'operator': 'equal',
       'value': 50
     }]
@@ -82,7 +66,7 @@ module.exports.percentageRule = {
 module.exports.discountRule = {
   'conditions': {
     'all': [{
-      'fact': 'duration',
+      'fact': 'userScore',
       'operator': 'equal',
       'value': 50
     }]
@@ -98,7 +82,7 @@ module.exports.discountRule = {
 module.exports.surchargeRule = {
   'conditions': {
     'all': [{
-      'fact': 'duration',
+      'fact': 'distance',
       'operator': 'equal',
       'value': 50
     }]

--- a/test/shipment_cost_test.js
+++ b/test/shipment_cost_test.js
@@ -27,225 +27,258 @@ function checkCost (err, res, expectedResult) {
 }
 
 async function create (rules) {
-  rules.forEach((aRule) => {
-    model.Rules.create({ json: JSON.stringify(aRule) })
+  return rules.forEach((aRule) => {
+    return model.Rules.create({ json: JSON.stringify(aRule) })
   })
 }
 
 async function addRule (rules) {
-  truncate('Rules')
-  create(rules)
+  return create(rules)
 }
 
 describe('shipment cost test', function () {
+  beforeEach(async () => { return truncate('Rules') })
+
   it('should receive shipment cost value that is zero', function (done) {
     addRule([freeRule])
-    chai.request(server)
-      .post('/shipment-cost')
-      .send({ 'email': 'jorge@comprame.com' })
-      .end(function (err, res) {
-        checkCost(err, res, { status: 'free', cost: 0 })
-        done()
+      .then(() => {
+        chai.request(server)
+          .post('/shipment-cost')
+          .send({ 'email': 'jorge@comprame.com' })
+          .end(function (err, res) {
+            checkCost(err, res, { status: 'free', cost: 0 })
+            done()
+          })
       })
   })
   it('Negative score should receive a null shipment cost value', function (done) {
     addRule([disabledRule])
-    chai.request(server)
-      .post('/shipment-cost')
-      .send({ 'userScore': -3 })
-      .end(function (err, res) {
-        checkCost(err, res, { status: 'disabled', cost: null })
-        done()
+      .then(() => {
+        chai.request(server)
+          .post('/shipment-cost')
+          .send({ 'userScore': -3 })
+          .end(function (err, res) {
+            checkCost(err, res, { status: 'disabled', cost: null })
+            done()
+          })
       })
   })
   it('Should receive a shipment cost value multiple of the distance', function (done) {
     addRule([factorRule])
-    chai.request(server)
-      .post('/shipment-cost')
-      .send({ 'distance': 35 })
-      .end(function (err, res) {
-        checkCost(err, res, { status: 'enabled', cost: 525 })
-        done()
+      .then(() => {
+        chai.request(server)
+          .post('/shipment-cost')
+          .send({ 'distance': 35 })
+          .end(function (err, res) {
+            checkCost(err, res, { status: 'enabled', cost: 525 })
+            done()
+          })
       })
   })
   it('Disable answer must prevail', function (done) {
-    addRule([freeRule, disabledRule, factorRule])
     const facts = {
       'email': 'jorge@comprame.com',
       'userScore': -3,
       'distance': 35
     }
-    chai.request(server)
-      .post('/shipment-cost')
-      .send(facts)
-      .end(function (err, res) {
-        checkCost(err, res, { status: 'disabled', cost: null })
-        done()
+    addRule([freeRule, disabledRule, factorRule])
+      .then(() => {
+        chai.request(server)
+          .post('/shipment-cost')
+          .send(facts)
+          .end(function (err, res) {
+            checkCost(err, res, { status: 'disabled', cost: null })
+            done()
+          })
       })
   })
   it('should receive free cost because of only percentage rule', function (done) {
     addRule([percentageRule])
-    chai.request(server)
-      .post('/shipment-cost')
-      .send({ 'userScore': 50 })
-      .end(function (err, res) {
-        checkCost(err, res, { status: 'enabled', cost: 0 })
-        done()
+      .then(() => {
+        chai.request(server)
+          .post('/shipment-cost')
+          .send({ 'userScore': 50 })
+          .end(function (err, res) {
+            checkCost(err, res, { status: 'enabled', cost: 0 })
+            done()
+          })
       })
   })
   it('Factor rule should apply first because of mayor priority', function (done) {
     addRule([percentageRule, factorRule])
-    chai.request(server)
-      .post('/shipment-cost')
-      .send({ 'distance': 40, userScore: 50 })
-      .end(function (err, res) {
-        checkCost(err, res, { status: 'enabled', cost: 540 })
-        done()
+      .then(() => {
+        chai.request(server)
+          .post('/shipment-cost')
+          .send({ 'distance': 40, userScore: 50 })
+          .end(function (err, res) {
+            checkCost(err, res, { status: 'enabled', cost: 540 })
+            done()
+          })
       })
   })
   it('percentage and discount rules should apply in parallel', function (done) {
     addRule([percentageRule, factorRule, discountRule])
-    chai.request(server)
-      .post('/shipment-cost')
-      .send({ 'distance': 40, 'userScore': 50 })
-      .end(function (err, res) {
-        checkCost(err, res, { status: 'enabled', cost: 531 })
-        done()
+      .then(() => {
+        chai.request(server)
+          .post('/shipment-cost')
+          .send({ 'distance': 40, 'userScore': 50 })
+          .end(function (err, res) {
+            checkCost(err, res, { status: 'enabled', cost: 531 })
+            done()
+          })
       })
   })
   it('get cost with several facts and only one rule', function (done) {
-    addRule([factorRule])
     const facts = {
       'email': 'jorge@comprame.com',
       'userScore': -3,
       'distance': 40
     }
-    chai.request(server)
-      .post('/shipment-cost')
-      .send(facts)
-      .end(function (err, res) {
-        checkCost(err, res, { status: 'enabled', cost: 600 })
-        done()
+    addRule([factorRule])
+      .then(() => {
+        chai.request(server)
+          .post('/shipment-cost')
+          .send(facts)
+          .end(function (err, res) {
+            checkCost(err, res, { status: 'enabled', cost: 600 })
+            done()
+          })
       })
   })
   it('should get a surcharge', function (done) {
-    addRule([surchargeRule])
     const facts = {
       'email': 'jorge@comprame.com',
       'userScore': -3,
       'distance': 50
     }
-    chai.request(server)
-      .post('/shipment-cost')
-      .send(facts)
-      .end(function (err, res) {
-        checkCost(err, res, { status: 'enabled', cost: 10 })
-        done()
+    addRule([surchargeRule])
+      .then(() => {
+        chai.request(server)
+          .post('/shipment-cost')
+          .send(facts)
+          .end(function (err, res) {
+            checkCost(err, res, { status: 'enabled', cost: 10 })
+            done()
+          })
       })
   })
   it('should get a sum', function (done) {
-    addRule([sumRule])
     const facts = {
       'email': 'jorge@comprame.com',
       'userScore': -3,
       'monthtrips': 12
     }
-    chai.request(server)
-      .post('/shipment-cost')
-      .send(facts)
-      .end(function (err, res) {
-        checkCost(err, res, { status: 'enabled', cost: 20 })
-        done()
+    addRule([sumRule])
+      .then(() => {
+        chai.request(server)
+          .post('/shipment-cost')
+          .send(facts)
+          .end(function (err, res) {
+            checkCost(err, res, { status: 'enabled', cost: 20 })
+            done()
+          })
       })
   })
   it('should apply only rules that match with facts', function (done) {
-    addRule([sumRule, surchargeRule])
     const facts = {
       'email': 'jorge@comprame.com',
       'userScore': -3,
       'monthtrips': 12
     }
-    chai.request(server)
-      .post('/shipment-cost')
-      .send(facts)
-      .end(function (err, res) {
-        checkCost(err, res, { status: 'enabled', cost: 20 })
-        done()
+    addRule([sumRule, surchargeRule])
+      .then(() => {
+        chai.request(server)
+          .post('/shipment-cost')
+          .send(facts)
+          .end(function (err, res) {
+            checkCost(err, res, { status: 'enabled', cost: 20 })
+            done()
+          })
       })
   })
   it('should FAIL because of invalid type', function (done) {
-    addRule([sumRule, surchargeRule])
     const facts = {
       'email': 3,
       'userScore': -3,
       'monthtrips': 12
     }
-    chai.request(server)
-      .post('/shipment-cost')
-      .send(facts)
-      .end(function (err, res) {
-        should.equal(err, null)
-        res.should.have.status(httpStatus.UNPROCESSABLE_ENTITY)
-        res.body.should.have.property('success')
-        res.body.success.should.be.equal(false)
-        done()
+    addRule([sumRule, surchargeRule])
+      .then(() => {
+        chai.request(server)
+          .post('/shipment-cost')
+          .send(facts)
+          .end(function (err, res) {
+            should.equal(err, null)
+            res.should.have.status(httpStatus.UNPROCESSABLE_ENTITY)
+            res.body.should.have.property('success')
+            res.body.success.should.be.equal(false)
+            done()
+          })
       })
   })
   it('should FAIL because of latitude invalid type', function (done) {
-    addRule([sumRule, surchargeRule])
     const facts = {
       'latitude': '',
       'userScore': -3,
       'monthtrips': 12
     }
-    chai.request(server)
-      .post('/shipment-cost')
-      .send(facts)
-      .end(function (err, res) {
-        should.equal(err, null)
-        res.should.have.status(httpStatus.UNPROCESSABLE_ENTITY)
-        res.body.should.have.property('success')
-        res.body.success.should.be.equal(false)
-        done()
+    addRule([sumRule, surchargeRule])
+      .then(() => {
+        chai.request(server)
+          .post('/shipment-cost')
+          .send(facts)
+          .end(function (err, res) {
+            should.equal(err, null)
+            res.should.have.status(httpStatus.UNPROCESSABLE_ENTITY)
+            res.body.should.have.property('success')
+            res.body.success.should.be.equal(false)
+            done()
+          })
       })
   })
   it('should FAIL because of invalid posted data', function (done) {
     addRule([sumRule])
-    chai.request(server)
-      .post('/shipment-cost')
-      .send([])
-      .end(function (err, res) {
-        should.equal(err, null)
-        res.should.have.status(httpStatus.UNPROCESSABLE_ENTITY)
-        res.body.should.have.property('success')
-        res.body.success.should.be.equal(false)
-        done()
+      .then(() => {
+        chai.request(server)
+          .post('/shipment-cost')
+          .send([])
+          .end(function (err, res) {
+            should.equal(err, null)
+            res.should.have.status(httpStatus.UNPROCESSABLE_ENTITY)
+            res.body.should.have.property('success')
+            res.body.success.should.be.equal(false)
+            done()
+          })
       })
   })
   it('should FAIL because of invalid tripTime', function (done) {
     addRule([sumRule])
-    chai.request(server)
-      .post('/shipment-cost')
-      .send({ 'tripTime': null })
-      .end(function (err, res) {
-        should.equal(err, null)
-        res.should.have.status(httpStatus.UNPROCESSABLE_ENTITY)
-        res.body.should.have.property('success')
-        res.body.success.should.be.equal(false)
-        done()
+      .then(() => {
+        chai.request(server)
+          .post('/shipment-cost')
+          .send({ 'tripTime': null })
+          .end(function (err, res) {
+            should.equal(err, null)
+            res.should.have.status(httpStatus.UNPROCESSABLE_ENTITY)
+            res.body.should.have.property('success')
+            res.body.success.should.be.equal(false)
+            done()
+          })
       })
   })
   it('should FAIL because of invalid userScore', function (done) {
     addRule([sumRule])
-    chai.request(server)
-      .post('/shipment-cost')
-      .send({ 'userScore': 'invalid' })
-      .end(function (err, res) {
-        should.equal(err, null)
-        res.should.have.status(httpStatus.UNPROCESSABLE_ENTITY)
-        res.body.should.have.property('success')
-        res.body.success.should.be.equal(false)
-        done()
+      .then(() => {
+        chai.request(server)
+          .post('/shipment-cost')
+          .send({ 'userScore': 'invalid' })
+          .end(function (err, res) {
+            should.equal(err, null)
+            res.should.have.status(httpStatus.UNPROCESSABLE_ENTITY)
+            res.body.should.have.property('success')
+            res.body.success.should.be.equal(false)
+            done()
+          })
       })
   })
   it('should get disabled if no fact is sent', function (done) {
@@ -256,6 +289,18 @@ describe('shipment cost test', function () {
       .end(function (err, res) {
         checkCost(err, res, { status: 'disabled', cost: null })
         done()
+      })
+  })
+  it('should FAIL invalid facts', function (done) {
+    addRule([sumRule])
+      .then(() => {
+        chai.request(server)
+          .post('/shipment-cost')
+          .send({ a: { b: { c: { d: { e: 'f' } } } } })
+          .end(function (err, res) {
+            checkCost(err, res, { status: 'disabled', cost: null })
+            done()
+          })
       })
   })
   after(function (done) {

--- a/test/shipment_cost_test.js
+++ b/test/shipment_cost_test.js
@@ -26,11 +26,15 @@ function checkCost (err, res, expectedResult) {
   should.equal(JSON.stringify(cost), JSON.stringify(expectedResult))
 }
 
-function addRule (rules) {
-  truncate('Rules')
+async function create (rules) {
   rules.forEach((aRule) => {
     model.Rules.create({ json: JSON.stringify(aRule) })
   })
+}
+
+async function addRule (rules) {
+  truncate('Rules')
+  create(rules)
 }
 
 describe('shipment cost test', function () {

--- a/test/shipment_cost_test.js
+++ b/test/shipment_cost_test.js
@@ -26,14 +26,12 @@ function checkCost (err, res, expectedResult) {
   should.equal(JSON.stringify(cost), JSON.stringify(expectedResult))
 }
 
-async function create (rules) {
-  return rules.forEach((aRule) => {
-    return model.Rules.create({ json: JSON.stringify(aRule) })
-  })
-}
-
 async function addRule (rules) {
-  return create(rules)
+  let promise
+  rules.forEach((aRule) => {
+    promise = model.Rules.create({ json: JSON.stringify(aRule) })
+  })
+  return promise
 }
 
 describe('shipment cost test', function () {

--- a/test/shipment_cost_test.js
+++ b/test/shipment_cost_test.js
@@ -3,12 +3,12 @@ const should = require('should')
 const app = require('../server/index')
 const server = app.listen()
 const truncate = require('../scripts/db/truncate')
+const model = require('../server/models')
 const httpStatus = require('http-status-codes')
 const {
   freeRule,
   disabledRule,
   factorRule,
-  minPriceRule,
   percentageRule,
   discountRule,
   surchargeRule,
@@ -16,216 +16,131 @@ const {
 } = require('./shipment_cost_definitions')
 chai.use(require('chai-http'))
 
-function ruleCheck (err, res, jsonRule) {
-  should.equal(err, null)
-  res.should.have.status(httpStatus.CREATED)
-  res.body.should.be.a('object')
-  res.body.should.have.property('success')
-  res.body.success.should.be.equal(true)
-  res.body.should.have.property('rule')
-  res.body.rule.should.have.property('json')
-  res.body.rule.json.should.equal(jsonRule)
-}
-
 function checkCost (err, res, expectedResult) {
-  if (err !== null) {
-    console.log('++++++++++++++++++++++++++++++++++++++++++++++')
-    console.log('ERROR: ', err)
-    console.log('++++++++++++++++++++++++++++++++++++++++++++++')
-  }
   should.equal(err, null)
   res.should.have.status(httpStatus.OK)
-  should.equal(JSON.stringify(res.body), JSON.stringify(expectedResult))
+  res.body.should.have.property('success')
+  res.body.should.have.property('cost')
+  const { success, cost } = res.body
+  success.should.be.equal(true)
+  should.equal(JSON.stringify(cost), JSON.stringify(expectedResult))
 }
 
-function postRulesVector (rules, server, done) {
-  rules.forEach((aRule, idx) => {
-    let jsonRule = JSON.stringify(aRule)
-    chai.request(server)
-      // { success: true, rule: rule }
-      .post('/rules')
-      .send({ json: jsonRule })
-      .end(function (err, res) {
-        ruleCheck(err, res, jsonRule)
-        if (idx === rules.length - 1) {
-          setImmediate(done)
-        }
-      })
+function addRule (rules) {
+  truncate('Rules')
+  rules.forEach((aRule) => {
+    model.Rules.create({ json: JSON.stringify(aRule) })
   })
 }
 
 describe('shipment cost test', function () {
-  // --------------------------------------------------------------------
-  it('Post a free rule', function (done) {
-    truncate('Rules')
-    postRulesVector([freeRule], server, done)
-  })
   it('should receive shipment cost value that is zero', function (done) {
+    addRule([freeRule])
     chai.request(server)
       .post('/shipment-cost')
       .send({ 'email': 'jorge@comprame.com' })
       .end(function (err, res) {
         checkCost(err, res, { status: 'free', cost: 0 })
-        setImmediate(done)
+        done()
       })
   })
-  // --------------------------------------------------------------------
-  it('Post a disabled rule', function (done) {
-    truncate('Rules')
-    postRulesVector([disabledRule], server, done)
-  })
   it('Negative score should receive a null shipment cost value', function (done) {
+    addRule([disabledRule])
     chai.request(server)
       .post('/shipment-cost')
       .send({ 'userScore': -3 })
       .end(function (err, res) {
         checkCost(err, res, { status: 'disabled', cost: null })
-        setImmediate(done)
+        done()
       })
   })
-  // --------------------------------------------------------------------
-  it('Post a factor rule', function (done) {
-    truncate('Rules')
-    postRulesVector([factorRule], server, done)
-  })
   it('Should receive a shipment cost value multiple of the distance', function (done) {
+    addRule([factorRule])
     chai.request(server)
       .post('/shipment-cost')
       .send({ 'distance': 35 })
       .end(function (err, res) {
         checkCost(err, res, { status: 'enabled', cost: 525 })
-        setImmediate(done)
+        done()
       })
-  })
-  // --------------------------------------------------------------------
-  it('Post a minimun price rule', function (done) {
-    truncate('Rules')
-    postRulesVector([minPriceRule], server, done)
-  })
-  it('should receive disable answer', function (done) {
-    chai.request(server)
-      .post('/shipment-cost')
-      .send({ 'price': 35 })
-      .end(function (err, res) {
-        checkCost(err, res, { status: 'disabled', cost: null })
-        setImmediate(done)
-      })
-  })
-  // --------------------------------------------------------------------
-  it('Post several rules', function (done) {
-    truncate('Rules')
-    const rulesVector = [freeRule, disabledRule, factorRule, minPriceRule]
-    postRulesVector(rulesVector, server, done)
   })
   it('Disable answer must prevail', function (done) {
+    addRule([freeRule, disabledRule, factorRule])
     const facts = {
       'email': 'jorge@comprame.com',
       'userScore': -3,
-      'distance': 35,
-      'price': 35
+      'distance': 35
     }
     chai.request(server)
       .post('/shipment-cost')
       .send(facts)
       .end(function (err, res) {
         checkCost(err, res, { status: 'disabled', cost: null })
-        setImmediate(done)
+        done()
       })
-  })
-  // --------------------------------------------------------------------
-  it('Post percentage rule', function (done) {
-    truncate('Rules')
-    const rulesVector = [percentageRule]
-    postRulesVector(rulesVector, server, done)
   })
   it('should receive free cost because of only percentage rule', function (done) {
+    addRule([percentageRule])
     chai.request(server)
       .post('/shipment-cost')
-      .send({ 'duration': 50 })
+      .send({ 'userScore': 50 })
       .end(function (err, res) {
         checkCost(err, res, { status: 'enabled', cost: 0 })
-        setImmediate(done)
+        done()
       })
-  })
-  // --------------------------------------------------------------------
-  it('Post percentage and factor rule', function (done) {
-    truncate('Rules')
-    const rulesVector = [percentageRule, factorRule]
-    postRulesVector(rulesVector, server, done)
   })
   it('Factor rule should apply first because of mayor priority', function (done) {
+    addRule([percentageRule, factorRule])
     chai.request(server)
       .post('/shipment-cost')
-      .send({ 'duration': 50, 'distance': 40 })
+      .send({ 'distance': 40, userScore: 50 })
       .end(function (err, res) {
         checkCost(err, res, { status: 'enabled', cost: 540 })
-        setImmediate(done)
+        done()
       })
-  })
-  // --------------------------------------------------------------------
-  it('Post percentage, factor and discount rule', function (done) {
-    truncate('Rules')
-    const rulesVector = [percentageRule, factorRule, discountRule]
-    postRulesVector(rulesVector, server, done)
   })
   it('percentage and discount rules should apply in parallel', function (done) {
+    addRule([percentageRule, factorRule, discountRule])
     chai.request(server)
       .post('/shipment-cost')
-      .send({ 'duration': 50, 'distance': 40 })
+      .send({ 'distance': 40, 'userScore': 50 })
       .end(function (err, res) {
         checkCost(err, res, { status: 'enabled', cost: 531 })
-        setImmediate(done)
+        done()
       })
   })
-  // --------------------------------------------------------------------
-  it('Post only a factor', function (done) {
-    truncate('Rules')
-    const rulesVector = [factorRule]
-    postRulesVector(rulesVector, server, done)
-  })
   it('get cost with several facts and only one rule', function (done) {
+    addRule([factorRule])
     const facts = {
       'email': 'jorge@comprame.com',
       'userScore': -3,
-      'distance': 40,
-      'price': 35
+      'distance': 40
     }
     chai.request(server)
       .post('/shipment-cost')
       .send(facts)
       .end(function (err, res) {
         checkCost(err, res, { status: 'enabled', cost: 600 })
-        setImmediate(done)
+        done()
       })
   })
-  // --------------------------------------------------------------------
-  it('Post a surcharge rule', function (done) {
-    truncate('Rules')
-    const rulesVector = [surchargeRule]
-    postRulesVector(rulesVector, server, done)
-  })
   it('should get a surcharge', function (done) {
+    addRule([surchargeRule])
     const facts = {
       'email': 'jorge@comprame.com',
       'userScore': -3,
-      'duration': 50,
-      'price': 35
+      'distance': 50
     }
     chai.request(server)
       .post('/shipment-cost')
       .send(facts)
       .end(function (err, res) {
         checkCost(err, res, { status: 'enabled', cost: 10 })
-        setImmediate(done)
+        done()
       })
-  })
-  // --------------------------------------------------------------------
-  it('Post a sum rule', function (done) {
-    truncate('Rules')
-    const rulesVector = [sumRule]
-    postRulesVector(rulesVector, server, done)
   })
   it('should get a sum', function (done) {
+    addRule([sumRule])
     const facts = {
       'email': 'jorge@comprame.com',
       'userScore': -3,
@@ -236,16 +151,11 @@ describe('shipment cost test', function () {
       .send(facts)
       .end(function (err, res) {
         checkCost(err, res, { status: 'enabled', cost: 20 })
-        setImmediate(done)
+        done()
       })
-  })
-  // --------------------------------------------------------------------
-  it('post unused rules', function (done) {
-    truncate('Rules')
-    const rulesVector = [sumRule, surchargeRule, minPriceRule]
-    postRulesVector(rulesVector, server, done)
   })
   it('should apply only rules that match with facts', function (done) {
+    addRule([sumRule, surchargeRule])
     const facts = {
       'email': 'jorge@comprame.com',
       'userScore': -3,
@@ -256,10 +166,94 @@ describe('shipment cost test', function () {
       .send(facts)
       .end(function (err, res) {
         checkCost(err, res, { status: 'enabled', cost: 20 })
-        setImmediate(done)
+        done()
       })
   })
-  // --------------------------------------------------------------------
+  it('should FAIL because of invalid type', function (done) {
+    addRule([sumRule, surchargeRule])
+    const facts = {
+      'email': 3,
+      'userScore': -3,
+      'monthtrips': 12
+    }
+    chai.request(server)
+      .post('/shipment-cost')
+      .send(facts)
+      .end(function (err, res) {
+        should.equal(err, null)
+        res.should.have.status(httpStatus.UNPROCESSABLE_ENTITY)
+        res.body.should.have.property('success')
+        res.body.success.should.be.equal(false)
+        done()
+      })
+  })
+  it('should FAIL because of latitude invalid type', function (done) {
+    addRule([sumRule, surchargeRule])
+    const facts = {
+      'latitude': '',
+      'userScore': -3,
+      'monthtrips': 12
+    }
+    chai.request(server)
+      .post('/shipment-cost')
+      .send(facts)
+      .end(function (err, res) {
+        should.equal(err, null)
+        res.should.have.status(httpStatus.UNPROCESSABLE_ENTITY)
+        res.body.should.have.property('success')
+        res.body.success.should.be.equal(false)
+        done()
+      })
+  })
+  it('should FAIL because of invalid posted data', function (done) {
+    addRule([sumRule])
+    chai.request(server)
+      .post('/shipment-cost')
+      .send([])
+      .end(function (err, res) {
+        should.equal(err, null)
+        res.should.have.status(httpStatus.UNPROCESSABLE_ENTITY)
+        res.body.should.have.property('success')
+        res.body.success.should.be.equal(false)
+        done()
+      })
+  })
+  it('should FAIL because of invalid tripTime', function (done) {
+    addRule([sumRule])
+    chai.request(server)
+      .post('/shipment-cost')
+      .send({ 'tripTime': null })
+      .end(function (err, res) {
+        should.equal(err, null)
+        res.should.have.status(httpStatus.UNPROCESSABLE_ENTITY)
+        res.body.should.have.property('success')
+        res.body.success.should.be.equal(false)
+        done()
+      })
+  })
+  it('should FAIL because of invalid userScore', function (done) {
+    addRule([sumRule])
+    chai.request(server)
+      .post('/shipment-cost')
+      .send({ 'userScore': 'invalid' })
+      .end(function (err, res) {
+        should.equal(err, null)
+        res.should.have.status(httpStatus.UNPROCESSABLE_ENTITY)
+        res.body.should.have.property('success')
+        res.body.success.should.be.equal(false)
+        done()
+      })
+  })
+  it('should get disabled if no fact is sent', function (done) {
+    // addRule([sumRule])
+    chai.request(server)
+      .post('/shipment-cost')
+      .send({})
+      .end(function (err, res) {
+        checkCost(err, res, { status: 'disabled', cost: null })
+        done()
+      })
+  })
   after(function (done) {
     truncate('Rules')
     server.close()

--- a/test/user_test.js
+++ b/test/user_test.js
@@ -138,7 +138,7 @@ describe('User controller', function () {
           })
       })
   })
-  it('Shoul Fail name too long', (done) => {
+  it('Should Fail name too long', (done) => {
     const requestBody = {
       name: 'namenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamename',
       email: 'email@example.com',

--- a/test/user_test.js
+++ b/test/user_test.js
@@ -138,4 +138,22 @@ describe('User controller', function () {
           })
       })
   })
+  it('Shoul Fail name too long', (done) => {
+    const requestBody = {
+      name: 'namenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamenamename',
+      email: 'email@example.com',
+      pass: 'example',
+      enabled: 'pedro'
+    }
+    chai
+      .request(server)
+      .post(baseURL)
+      .send(requestBody)
+      .end((err, res) => {
+        should.equal(err, null)
+        res.should.have.status(httpStatus.INTERNAL_SERVER_ERROR)
+        res.body.should.have.property('errors')
+        done()
+      })
+  })
 })


### PR DESCRIPTION
closed #33 #72 
Este branch implementa la posibilidad de simular el calculo del costo de envio por front end, ademas se arreglaron los tests de shipment cost donde se borraron test unitarios para arreglar reglas por funciones asi se respeta cierto compatibilidad respecto de los test de los otros módulos.
También se modifico la interfaz de respuesta del endpoint ```shipment-cost``` donde ahora en caso de éxito se devuelve:
- ```{ succes: true, cost: { status: 'free', cost: 0 } }```  (por ejemplo)
y en caso de error:
- ```{ succes: false, errors: err }```

Esto se hizo para mantener la convencion.