### PR TITLE
Readjust shipment cost

### DIFF
--- a/client/src/components/rulesForm.js
+++ b/client/src/components/rulesForm.js
@@ -11,7 +11,7 @@ import {
 } from 'react-bootstrap'
 import PropTypes from 'prop-types'
 import RuleTranslator from '../service/ruleTranslator'
-import { facts, ops, type, factsDefaultValues } from './rules_data'
+import { facts, ops, type, factsDefaultValues, factOps } from './rules_data'
 
 export default class RulesForm extends React.Component {
   constructor (props) {
@@ -22,12 +22,12 @@ export default class RulesForm extends React.Component {
     this.state = {
       conditions: [],
       fact: this.facts[0],
-      value: 10,
+      value: null,
       operator: this.ops[0],
       type: this.type[0],
       params: 10
     }
-    this.defaultValue = factsDefaultValues[this.state.fact]
+    this.defaultValue = factsDefaultValues[this.facts[0]]
   }
 
   checkValue (name, event) {
@@ -42,9 +42,13 @@ export default class RulesForm extends React.Component {
   handleChange = name => event => {
     this.setState({
       [name]: this.checkValue(name, event)
+
     })
     if (name === 'fact') {
       this.defaultValue = factsDefaultValues[event.target.value]
+      this.setState({
+        operator: factOps[event.target.value][0]
+      })
     }
   }
 
@@ -61,11 +65,20 @@ export default class RulesForm extends React.Component {
     )
   }
 
+  getValue (value) {
+    if (JSON.stringify(value) === 'null') {
+      return this.defaultValue
+    } else if (JSON.stringify(value) === 'NaN') {
+      return this.defaultValue
+    }
+    return value
+  }
+
   addCondition = () => {
     this.state.conditions.push({
       fact: this.state.fact,
       operator: this.state.operator,
-      value: this.state.value
+      value: this.getValue(this.state.value)
     })
     this.setState({
       'conditions': this.state.conditions
@@ -90,7 +103,7 @@ export default class RulesForm extends React.Component {
             { this.showOptions(this.facts) }
           </FormControl>
           <FormControl componentClass="select" placeholder="Type" onChange={this.handleChange('operator')}>
-            { this.showOptions(this.ops) }
+            { this.showOptions(factOps[this.state.fact]) }
           </FormControl>
           <FormControl type="text" placeholder={this.defaultValue} onChange={this.handleChange('value')}/>
         </Col>
@@ -118,7 +131,7 @@ export default class RulesForm extends React.Component {
           <FormControl componentClass="select" placeholder="Type" onChange={this.handleChange('type')}>
             { this.showOptions(this.type) }
           </FormControl>
-          <FormControl type="text" placeholder={this.defaultValue} onChange={this.handleChange('params')}/>
+          <FormControl type="text" placeholder='10' onChange={this.handleChange('params')}/>
         </Col>
       </FormGroup>
     )

--- a/client/src/components/rulesForm.js
+++ b/client/src/components/rulesForm.js
@@ -11,7 +11,7 @@ import {
 } from 'react-bootstrap'
 import PropTypes from 'prop-types'
 import RuleTranslator from '../service/ruleTranslator'
-import { facts, ops, type } from './rules_data'
+import { facts, ops, type, factsDefaultValues } from './rules_data'
 
 export default class RulesForm extends React.Component {
   constructor (props) {
@@ -19,7 +19,6 @@ export default class RulesForm extends React.Component {
     this.facts = facts
     this.ops = ops
     this.type = type
-    this.defaultValue = '10'
     this.state = {
       conditions: [],
       fact: this.facts[0],
@@ -28,6 +27,7 @@ export default class RulesForm extends React.Component {
       type: this.type[0],
       params: 10
     }
+    this.defaultValue = factsDefaultValues[this.state.fact]
   }
 
   checkValue (name, event) {
@@ -43,6 +43,9 @@ export default class RulesForm extends React.Component {
     this.setState({
       [name]: this.checkValue(name, event)
     })
+    if (name === 'fact') {
+      this.defaultValue = factsDefaultValues[event.target.value]
+    }
   }
 
   submit = (event) => {

--- a/client/src/components/rules_data.js
+++ b/client/src/components/rules_data.js
@@ -1,20 +1,25 @@
+module.exports.factsDefaultValues = {
+  'antiquity': 10,
+  'email': 'test@gmail.com',
+  'userScore': 15,
+  'paymentMethod': 'cash',
+  'distance': 35,
+  'latitude': 37.658974,
+  'longitude': -5.526148,
+  'tripDate': '2017/03/28',
+  'tripTime': '13:30:00'
+}
+
 module.exports.facts = [
-  'daytrips',
-  'monthtrips',
   'antiquity',
+  'email',
   'userScore',
   'paymentMethod',
-  'duration',
   'distance',
-  'latitud',
-  'longitud',
-  'date',
-  'time',
-  'serverId',
+  'latitude',
+  'longitude',
   'tripDate',
-  'tripTime',
-  'email',
-  'price'
+  'tripTime'
 ]
 module.exports.ops = [
   'equal',

--- a/client/src/components/rules_data.js
+++ b/client/src/components/rules_data.js
@@ -1,5 +1,17 @@
 module.exports.factsDefaultValues = {
   'antiquity': 10,
+  'email': '@gmail.com',
+  'userScore': 15,
+  'paymentMethod': 'cash',
+  'distance': 35,
+  'latitude': 37.658974,
+  'longitude': -5.526148,
+  'tripDate': '2017/03/28',
+  'tripTime': '13:30'
+}
+
+module.exports.defaultValues = {
+  'antiquity': 10,
   'email': 'test@gmail.com',
   'userScore': 15,
   'paymentMethod': 'cash',
@@ -8,6 +20,18 @@ module.exports.factsDefaultValues = {
   'longitude': -5.526148,
   'tripDate': '2017/03/28',
   'tripTime': '13:30'
+}
+
+module.exports.factOps = {
+  'antiquity': ['equal', 'greaterThanInclusive', 'lessThanInclusive', 'greaterThan', 'lessThan'],
+  'email': ['domainEqual'],
+  'userScore': ['equal', 'greaterThanInclusive', 'lessThanInclusive', 'greaterThan', 'lessThan'],
+  'paymentMethod': ['equal'],
+  'distance': ['equal', 'greaterThanInclusive', 'lessThanInclusive', 'greaterThan', 'lessThan'],
+  'latitude': ['equal', 'greaterThanInclusive', 'lessThanInclusive', 'greaterThan', 'lessThan'],
+  'longitude': ['equal', 'greaterThanInclusive', 'lessThanInclusive', 'greaterThan', 'lessThan'],
+  'tripDate': ['equal', 'greaterThanInclusive', 'lessThanInclusive', 'greaterThan', 'lessThan'],
+  'tripTime': ['equal', 'greaterThanInclusive', 'lessThanInclusive', 'greaterThan', 'lessThan']
 }
 
 module.exports.facts = [
@@ -21,6 +45,7 @@ module.exports.facts = [
   'tripDate',
   'tripTime'
 ]
+
 module.exports.ops = [
   'equal',
   'greaterThanInclusive',

--- a/client/src/components/rules_data.js
+++ b/client/src/components/rules_data.js
@@ -7,7 +7,7 @@ module.exports.factsDefaultValues = {
   'latitude': 37.658974,
   'longitude': -5.526148,
   'tripDate': '2017/03/28',
-  'tripTime': '13:30:00'
+  'tripTime': '13:30'
 }
 
 module.exports.facts = [

--- a/client/src/components/shipmentCostForm.js
+++ b/client/src/components/shipmentCostForm.js
@@ -11,7 +11,7 @@ import {
   HelpBlock
 } from 'react-bootstrap'
 import PropTypes from 'prop-types'
-import { facts, factsDefaultValues } from './rules_data'
+import { facts, defaultValues } from './rules_data'
 
 export default class ShipmentCostForm extends React.Component {
   constructor (props) {
@@ -22,7 +22,7 @@ export default class ShipmentCostForm extends React.Component {
       value: null,
       factsList: []
     }
-    this.defaultValue = factsDefaultValues[this.state.fact]
+    this.defaultValue = defaultValues[this.state.fact]
   }
 
   checkValue (name, event) {
@@ -39,7 +39,7 @@ export default class ShipmentCostForm extends React.Component {
       [name]: this.checkValue(name, event)
     })
     if (name === 'fact') {
-      this.defaultValue = factsDefaultValues[event.target.value]
+      this.defaultValue = defaultValues[event.target.value]
     }
   }
 
@@ -66,9 +66,18 @@ export default class ShipmentCostForm extends React.Component {
     )
   }
 
+  getValue (value) {
+    if (JSON.stringify(value) === 'null') {
+      return this.defaultValue
+    } else if (JSON.stringify(value) === 'NaN') {
+      return this.defaultValue
+    }
+    return value
+  }
+
   addFact = () => {
     this.state.factsList.push({
-      [this.state.fact]: this.state.value
+      [this.state.fact]: this.getValue(this.state.value)
     })
     this.setState({
       'factsList': this.state.factsList

--- a/client/src/components/shipmentCostForm.js
+++ b/client/src/components/shipmentCostForm.js
@@ -11,7 +11,7 @@ import {
   HelpBlock
 } from 'react-bootstrap'
 import PropTypes from 'prop-types'
-import { facts } from './rules_data'
+import { facts, factsDefaultValues } from './rules_data'
 
 export default class ShipmentCostForm extends React.Component {
   constructor (props) {
@@ -22,6 +22,7 @@ export default class ShipmentCostForm extends React.Component {
       value: null,
       factsList: []
     }
+    this.defaultValue = factsDefaultValues[this.state.fact]
   }
 
   checkValue (name, event) {
@@ -37,6 +38,9 @@ export default class ShipmentCostForm extends React.Component {
     this.setState({
       [name]: this.checkValue(name, event)
     })
+    if (name === 'fact') {
+      this.defaultValue = factsDefaultValues[event.target.value]
+    }
   }
 
   refresh () {
@@ -88,7 +92,7 @@ export default class ShipmentCostForm extends React.Component {
           <FormControl componentClass="select" placeholder="Type" onChange={this.handleChange('fact')}>
             { this.showOptions(this.facts) }
           </FormControl>
-          <FormControl type="text" placeholder="insert a value" onChange={this.handleChange('value')}/>
+          <FormControl type="text" placeholder={this.defaultValue} onChange={this.handleChange('value')}/>
         </Col>
         <Col smOffset={12} sm={10}>
           <Button type="button" onClick={ this.addFact }>

--- a/client/src/containers/shipmentCostContainer.js
+++ b/client/src/containers/shipmentCostContainer.js
@@ -29,12 +29,14 @@ export default class RulesContainer extends React.Component {
         if (response.status === httpStatus.OK) {
           this.setState({
             errors: {},
-            cost: 'the cost is ' + response.content.cost.cost + ' because it is ' + response.content.cost.status
+            cost: JSON.stringify(response.content.cost)
           })
         } else {
-          this.setState({
-            errors: { value: response.content.errors }
-          })
+          if (response.status === httpStatus.UNPROCESSABLE_ENTITY) {
+            this.setState({
+              errors: { value: response.content.errors }
+            })
+          }
         }
       })
       .catch(err => {

--- a/server/controllers/shipment_cost_data_types.js
+++ b/server/controllers/shipment_cost_data_types.js
@@ -1,6 +1,4 @@
 module.exports.factsTypes = {
-  'daytrips': typeof 1,
-  'monthtrips': typeof 1,
   'antiquity': typeof 1,
   'email': typeof '',
   'userScore': typeof 1.1,

--- a/server/routes/shipment_cost.js
+++ b/server/routes/shipment_cost.js
@@ -4,8 +4,6 @@ const shipmentCostController = require('../controllers/shipment_cost')
 
 /*
 const {
-  daytrips, // (int)
-  monthtrips, // (int)
   antiquity  // (int)
   email, // (string)
   userScore,  // (float)

--- a/test/shipment_cost_definitions.js
+++ b/test/shipment_cost_definitions.js
@@ -98,7 +98,7 @@ module.exports.surchargeRule = {
 module.exports.sumRule = {
   'conditions': {
     'all': [{
-      'fact': 'monthtrips',
+      'fact': 'userScore',
       'operator': 'lessThan',
       'value': 15
     }]

--- a/test/shipment_cost_test.js
+++ b/test/shipment_cost_test.js
@@ -163,8 +163,7 @@ describe('shipment cost test', function () {
   it('should get a sum', function (done) {
     const facts = {
       'email': 'jorge@comprame.com',
-      'userScore': -3,
-      'monthtrips': 12
+      'userScore': 14
     }
     addRule([sumRule])
       .then(() => {
@@ -180,8 +179,7 @@ describe('shipment cost test', function () {
   it('should apply only rules that match with facts', function (done) {
     const facts = {
       'email': 'jorge@comprame.com',
-      'userScore': -3,
-      'monthtrips': 12
+      'userScore': 12
     }
     addRule([sumRule, surchargeRule])
       .then(() => {
@@ -197,8 +195,7 @@ describe('shipment cost test', function () {
   it('should FAIL because of invalid type', function (done) {
     const facts = {
       'email': 3,
-      'userScore': -3,
-      'monthtrips': 12
+      'userScore': -3
     }
     addRule([sumRule, surchargeRule])
       .then(() => {
@@ -217,8 +214,7 @@ describe('shipment cost test', function () {
   it('should FAIL because of latitude invalid type', function (done) {
     const facts = {
       'latitude': '',
-      'userScore': -3,
-      'monthtrips': 12
+      'userScore': -3
     }
     addRule([sumRule, surchargeRule])
       .then(() => {


### PR DESCRIPTION
closes #62 

Se borran ```facts``` que ya no forman parte de nuestra interfaz respetando nuestra definicion final que se encuentra en la [wiki](https://github.com/Taller-2/shared-server/wiki/Development#explicacion-de-que-tipo-de-datos-recibe-el-endpoint-shipment-cost).
Ademas se corrigió el valor default que aparece en el casillero a llenar del agregado de reglas y de simulación del costo de envió