### PR TITLE
Validate dates

### DIFF
--- a/client/src/components/rulesForm.js
+++ b/client/src/components/rulesForm.js
@@ -40,14 +40,15 @@ export default class RulesForm extends React.Component {
   }
 
   handleChange = name => event => {
+    let value = this.checkValue(name, event)
     this.setState({
-      [name]: this.checkValue(name, event)
+      [name]: value
 
     })
     if (name === 'fact') {
-      this.defaultValue = factsDefaultValues[event.target.value]
+      this.defaultValue = factsDefaultValues[value]
       this.setState({
-        operator: factOps[event.target.value][0]
+        operator: factOps[value][0]
       })
     }
   }

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "should": "^1.3.0",
     "truffle-hdwallet-provider": "0.0.3",
     "whatwg-url": "^7.0.0",
-    "node-fetch": "^2.2.1"
+    "node-fetch": "^2.2.1",
+    "moment": "^2.22.2"
   },
   "devDependencies": {
     "babel-cli": "^6.6.0",

--- a/server/controllers/rules.js
+++ b/server/controllers/rules.js
@@ -115,9 +115,29 @@ const isRuleValid = function (aJsonRule) {
   return isConditionValid(rule.conditions)
 }
 
+let moment = require('moment')
+
 exports.validateCreate = () => {
   return [
     body('json').custom(jsonRule => {
+      if (typeof jsonRule === typeof undefined) {
+        return true
+      }
+      let rule = JSON.parse(jsonRule)
+      for (let aCondition of rule.conditions.all) {
+        if (aCondition.fact === 'tripDate') {
+          let isDateValid = moment(aCondition.value, 'YYYY/MM/DD').format('YYYY/MM/DD') === aCondition.value
+          if (!isDateValid) {
+            return Promise.reject(new Error('tripDate should have format YYYY/MM/DD'))
+          }
+        }
+        if (aCondition.fact === 'tripTime') {
+          let isDateValid = moment(aCondition.value, 'h:mm A').format('HH:mm') === aCondition.value
+          if (!isDateValid) {
+            return Promise.reject(new Error('tripTime shoul have format HH:mm'))
+          }
+        }
+      }
       return model.Rules.findAll(
         { where: { json: jsonRule } }
       )

--- a/server/controllers/rules.js
+++ b/server/controllers/rules.js
@@ -134,7 +134,7 @@ exports.validateCreate = () => {
         if (aCondition.fact === 'tripTime') {
           let isDateValid = moment(aCondition.value, 'h:mm A').format('HH:mm') === aCondition.value
           if (!isDateValid) {
-            return Promise.reject(new Error('tripTime shoul have format HH:mm'))
+            return Promise.reject(new Error('tripTime should have format HH:mm'))
           }
         }
       }

--- a/server/controllers/shipment_cost.js
+++ b/server/controllers/shipment_cost.js
@@ -148,6 +148,7 @@ module.exports.getCost = async function (req, res) {
 
 const { body } = require('express-validator/check')
 const { factsTypes } = require('./shipment_cost_data_types')
+let moment = require('moment')
 
 exports.validateCreate = () => {
   let msg = ''
@@ -162,6 +163,18 @@ exports.validateCreate = () => {
           const expectedType = factsTypes[aFact]
           if (!(type === expectedType)) {
             return false
+          }
+          if (aFact === 'tripDate') {
+            let isDateValid = moment(aValue, 'YYYY/MM/DD').format('YYYY/MM/DD') === aValue
+            if (!isDateValid) {
+              return false
+            }
+          }
+          if (aFact === 'tripTime') {
+            let isDateValid = moment(aValue, 'h:mm A').format('HH:mm') === aValue
+            if (!isDateValid) {
+              return Promise.reject(new Error('tripTime shoul have format HH:mm'))
+            }
           }
         }
         return true

--- a/server/controllers/shipment_cost.js
+++ b/server/controllers/shipment_cost.js
@@ -167,7 +167,7 @@ exports.validateCreate = () => {
           if (aFact === 'tripDate') {
             let isDateValid = moment(aValue, 'YYYY/MM/DD').format('YYYY/MM/DD') === aValue
             if (!isDateValid) {
-              return false
+              return Promise.reject(new Error('tripDate should have format YYYY/MM/DD'))
             }
           }
           if (aFact === 'tripTime') {

--- a/server/controllers/shipment_cost.js
+++ b/server/controllers/shipment_cost.js
@@ -173,7 +173,7 @@ exports.validateCreate = () => {
           if (aFact === 'tripTime') {
             let isDateValid = moment(aValue, 'h:mm A').format('HH:mm') === aValue
             if (!isDateValid) {
-              return Promise.reject(new Error('tripTime shoul have format HH:mm'))
+              return Promise.reject(new Error('tripTime should have format HH:mm'))
             }
           }
         }

--- a/test/rules_definitions.js
+++ b/test/rules_definitions.js
@@ -79,3 +79,35 @@ module.exports.multipleConditionsRule = {
     }
   }
 }
+
+module.exports.InvalidTripTimeRule = {
+  'conditions': {
+    'all': [{
+      'fact': 'tripTime',
+      'operator': 'equal',
+      'value': '24:34'
+    }]
+  },
+  'event': {
+    'type': 'test',
+    'params': {
+      'data': 0
+    }
+  }
+}
+
+module.exports.InvalidTripDateRule = {
+  'conditions': {
+    'all': [{
+      'fact': 'tripDate',
+      'operator': 'equal',
+      'value': '02/12/2017'
+    }]
+  },
+  'event': {
+    'type': 'test',
+    'params': {
+      'data': 0
+    }
+  }
+}

--- a/test/rules_test.js
+++ b/test/rules_test.js
@@ -10,7 +10,9 @@ const {
   normalRule,
   emptyConditionRule,
   missingConditionRule,
-  multipleConditionsRule
+  multipleConditionsRule,
+  InvalidTripDateRule,
+  InvalidTripTimeRule
 } = require('./rules_definitions')
 
 const baseURL = '/rules'
@@ -206,6 +208,34 @@ describe('add simple rule', function () {
         // expected: { success: true, rule: rule }
         should.equal(err, null)
         res.should.have.status(httpStatus.INTERNAL_SERVER_ERROR)
+        res.body.should.be.a('object')
+        res.body.should.have.property('success')
+        res.body.success.should.be.equal(false)
+        done()
+      })
+  })
+  it('Should FAIL invalid trip date format', (done) => {
+    let jsonRule = JSON.stringify(InvalidTripDateRule)
+    chai.request(server)
+      .post(baseURL)
+      .send({ json: jsonRule })
+      .end(function (err, res) {
+        should.equal(err, null)
+        res.should.have.status(httpStatus.UNPROCESSABLE_ENTITY)
+        res.body.should.be.a('object')
+        res.body.should.have.property('success')
+        res.body.success.should.be.equal(false)
+        done()
+      })
+  })
+  it('Should FAIL invalid trip time format', (done) => {
+    let jsonRule = JSON.stringify(InvalidTripTimeRule)
+    chai.request(server)
+      .post(baseURL)
+      .send({ json: jsonRule })
+      .end(function (err, res) {
+        should.equal(err, null)
+        res.should.have.status(httpStatus.UNPROCESSABLE_ENTITY)
         res.body.should.be.a('object')
         res.body.should.have.property('success')
         res.body.success.should.be.equal(false)

--- a/test/shipment_cost_definitions.js
+++ b/test/shipment_cost_definitions.js
@@ -110,3 +110,35 @@ module.exports.sumRule = {
     }
   }
 }
+
+module.exports.tripDateRule = {
+  'conditions': {
+    'all': [{
+      'fact': 'tripDate',
+      'operator': 'lessThan',
+      'value': '2017/12/24'
+    }]
+  },
+  'event': {
+    'type': 'sum',
+    'params': {
+      'data': 20
+    }
+  }
+}
+
+module.exports.tripTimeRule = {
+  'conditions': {
+    'all': [{
+      'fact': 'tripTime',
+      'operator': 'lessThan',
+      'value': '13:34'
+    }]
+  },
+  'event': {
+    'type': 'sum',
+    'params': {
+      'data': 20
+    }
+  }
+}

--- a/test/shipment_cost_test.js
+++ b/test/shipment_cost_test.js
@@ -12,7 +12,9 @@ const {
   percentageRule,
   discountRule,
   surchargeRule,
-  sumRule
+  sumRule,
+  tripDateRule,
+  tripTimeRule
 } = require('./shipment_cost_definitions')
 chai.use(require('chai-http'))
 
@@ -293,6 +295,36 @@ describe('shipment cost test', function () {
           .send({ a: { b: { c: { d: { e: 'f' } } } } })
           .end(function (err, res) {
             checkCost(err, res, { status: 'disabled', cost: null })
+            done()
+          })
+      })
+  })
+  it('should FAIL invalid trip date', function (done) {
+    addRule([tripDateRule])
+      .then(() => {
+        chai.request(server)
+          .post('/shipment-cost')
+          .send({ 'tripDate': '20/12/2017' })
+          .end(function (err, res) {
+            should.equal(err, null)
+            res.should.have.status(httpStatus.UNPROCESSABLE_ENTITY)
+            res.body.should.have.property('success')
+            res.body.success.should.be.equal(false)
+            done()
+          })
+      })
+  })
+  it('should FAIL invalid trip time', function (done) {
+    addRule([tripTimeRule])
+      .then(() => {
+        chai.request(server)
+          .post('/shipment-cost')
+          .send({ 'tripTime': '24:24' })
+          .end(function (err, res) {
+            should.equal(err, null)
+            res.should.have.status(httpStatus.UNPROCESSABLE_ENTITY)
+            res.body.should.have.property('success')
+            res.body.success.should.be.equal(false)
             done()
           })
       })


### PR DESCRIPTION
closes #73 

Se usa el modulo ```moment``` donde se valida que el formato de ```tripDate```  sea ``` YYYY/MM/DD``` y el formato de tripTime sea ``` HH:MM```. Se puede comprobar que la comparaion entre strings es correcta ya que al estar en ese formato la comparacion es directa.
Luego hay que usar con cuidado la interfaz grafica ya que cuando muestra las opciones de ``` facts``` por ejemplo, cuando se refresca la pantalla quedan valores por defecto, pero en la lista se ve otra opción y es poco intuitivo, de  todas maneras se muestra que regla o condicion se agrega exactamente asique desde ese punto de vista cumple las espectativas. El problemas basicamente es que habria que hacer un gran refactor de todo el front end porque no se cunple con ningun patron de diseño, pero no hay tiempo.